### PR TITLE
Introduce 64-bit datatypes in CProcessImage structs

### DIFF
--- a/library/src/CProcessImageGenerator.cpp
+++ b/library/src/CProcessImageGenerator.cpp
@@ -86,14 +86,25 @@ const std::string CProcessImageGenerator::Generate(std::uint8_t nodeid, std::sha
 
 const std::string CProcessImageGenerator::PrintChannel(const std::string& name, const IEC_Datatype& type, const std::uint32_t size, const std::uint32_t, const boost::optional<std::uint32_t>&)
 {
+    IEC_Datatype usedType = type;
+    
+    if(type == IEC_Datatype::BITSTRING){
+        usedType = size > 32 ? IEC_Datatype::DWORD : IEC_Datatype::LWORD;
+    }
+    
 	std::stringstream channel;
-	switch (type)
+	switch (usedType)
 	{
 		case IEC_Datatype::SINT:
 		case IEC_Datatype::INT:
 		case IEC_Datatype::DINT:
-		case IEC_Datatype::LINT:
 			channel << "\tsigned ";
+			channel << Utilities::ClearModuleParameterUuid(name) << ":";
+			channel << std::dec << size;
+			channel << ";" << std::endl;
+			break;
+        case IEC_Datatype::LINT:
+            channel << "\tINT64 ";
 			channel << Utilities::ClearModuleParameterUuid(name) << ":";
 			channel << std::dec << size;
 			channel << ";" << std::endl;
@@ -101,19 +112,23 @@ const std::string CProcessImageGenerator::PrintChannel(const std::string& name, 
 		case IEC_Datatype::USINT:
 		case IEC_Datatype::UINT:
 		case IEC_Datatype::UDINT:
-		case IEC_Datatype::ULINT:
 		case IEC_Datatype::BOOL:
-		case IEC_Datatype::BITSTRING:
 		case IEC_Datatype::BYTE:
 		case IEC_Datatype::_CHAR:
 		case IEC_Datatype::WORD:
 		case IEC_Datatype::DWORD:
-		case IEC_Datatype::LWORD:
 			channel << "\tunsigned ";
 			channel << Utilities::ClearModuleParameterUuid(name) << ":";
 			channel << std::dec << size;
 			channel << ";" << std::endl;
 			break;
+        case IEC_Datatype::ULINT:
+        case IEC_Datatype::LWORD:
+            channel << "\tUINT64 ";
+			channel << Utilities::ClearModuleParameterUuid(name) << ":";
+			channel << std::dec << size;
+			channel << ";" << std::endl;
+            break;
 		case IEC_Datatype::REAL:
 			channel << "\tfloat ";
 			channel << Utilities::ClearModuleParameterUuid(name);


### PR DESCRIPTION
At least GCC complains about struct-members of type "unsigned" / "signed" and a width > 32 bit.
Commit Id29f4e52b574c38298425375eb1b2dcc921c156d solved this for padding variables, however there are still the 64-bit datatypes which result in similar issues.

As far as I know there is no standard 64-bit unsigned/signed integer datatype in C89 (long long was introduced in C99), therefore this patch introduced INT64 and UINT64 which have to be defined before including xap.h.

It also lowers bitstreams to scalar datatypes of appropriate type depending on its size.
